### PR TITLE
feat: list instrumented resources in Lumigo resource status

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,30 @@ spec:
       key: token # This must match the key in the Kubernetes secret
 ```
 
+Each `Lumigo` resource keeps in its state a list of resources it currently instruments:
+
+```yaml
+$ kubectl describe lumigo -n my-namespace
+Name:         lumigo
+Namespace:    my-namespace
+API Version:  operator.lumigo.io/v1alpha1
+Kind:         Lumigo
+Metadata:
+  ... # Data removed for readability
+Spec:
+  ... # Data removed for readability
+Status:
+  Conditions:
+  ... # Data removed for readability
+  Instrumented Resources:
+    API Version:       apps/v1
+    Kind:              StatefulSet
+    Name:              my-statefulset
+    Namespace:         my-namespace
+    Resource Version:  320123
+    UID:               93d6d809-ac2a-43a9-bc07-f0d4e314efcc
+```
+
 #### Opting out for specific resources
 
 To prevent the Lumigo Kubernetes operator from injecting tracing to pods managed by some resource in a namespace that contains a `Lumigo` resource, add the `lumigo.auto-trace` label set to `false`:

--- a/api/v1alpha1/lumigo_types.go
+++ b/api/v1alpha1/lumigo_types.go
@@ -121,6 +121,9 @@ type KubeEventsSpec struct {
 type LumigoStatus struct {
 	// The status of single Lumigo resources
 	Conditions []LumigoCondition `json:"conditions"`
+
+	// List of resources instrumented by this Lumigo instance
+	InstrumentedResources []corev1.ObjectReference `json:"instrumentedResources"`
 }
 
 type LumigoCondition struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -230,6 +231,11 @@ func (in *LumigoStatus) DeepCopyInto(out *LumigoStatus) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.InstrumentedResources != nil {
+		in, out := &in.InstrumentedResources, &out.InstrumentedResources
+		*out = make([]v1.ObjectReference, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/charts/lumigo-operator/templates/lumigo-crd.yaml
+++ b/charts/lumigo-operator/templates/lumigo-crd.yaml
@@ -130,8 +130,73 @@ spec:
                   - type
                   type: object
                 type: array
+              instrumentedResources:
+                description: List of resources instrumented by this Lumigo instance
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
             required:
             - conditions
+            - instrumentedResources
             type: object
         type: object
     served: true

--- a/config/crd/bases/operator.lumigo.io_lumigoes.yaml
+++ b/config/crd/bases/operator.lumigo.io_lumigoes.yaml
@@ -130,8 +130,73 @@ spec:
                   - type
                   type: object
                 type: array
+              instrumentedResources:
+                description: List of resources instrumented by this Lumigo instance
+                items:
+                  description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
             required:
             - conditions
+            - instrumentedResources
             type: object
         type: object
     served: true

--- a/controllers/internal/matchers/matchers_lumigo.go
+++ b/controllers/internal/matchers/matchers_lumigo.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2023 Lumigo.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+
+	operatorv1alpha1 "github.com/lumigo-io/lumigo-kubernetes-operator/api/v1alpha1"
+	"github.com/lumigo-io/lumigo-kubernetes-operator/controllers/conditions"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/reference"
+)
+
+func BeActive() types.GomegaMatcher {
+	return &beActive{}
+}
+
+type beActive struct {
+}
+
+func (m *beActive) Match(actual interface{}) (bool, error) {
+	var lumigo *operatorv1alpha1.Lumigo
+	switch a := actual.(type) {
+	case *operatorv1alpha1.Lumigo:
+		lumigo = a
+	default:
+		return false, fmt.Errorf("IsActive matcher expects a *operatorv1alpha1.Lumigo; got:\n%s", format.Object(actual, 1))
+	}
+
+	return conditions.IsActive(lumigo), nil
+}
+
+func (m *beActive) FailureMessage(actual interface{}) (message string) {
+	return "is not active"
+}
+
+func (m *beActive) NegatedFailureMessage(actual interface{}) (message string) {
+	return "is active"
+}
+
+func BeInErroneousState(expectedMessage string) types.GomegaMatcher {
+	return &beInErroneousState{
+		expectedMessage: expectedMessage,
+	}
+}
+
+type beInErroneousState struct {
+	expectedMessage string
+}
+
+func (m *beInErroneousState) Match(actual interface{}) (bool, error) {
+	var lumigo *operatorv1alpha1.Lumigo
+	switch a := actual.(type) {
+	case *operatorv1alpha1.Lumigo:
+		lumigo = a
+	default:
+		return false, fmt.Errorf("IsActive matcher expects a *operatorv1alpha1.Lumigo; got:\n%s", format.Object(actual, 1))
+	}
+
+	hasError, message := conditions.HasError(lumigo)
+
+	if len(m.expectedMessage) == 0 {
+		return hasError, nil
+	} else {
+		return m.expectedMessage == message, nil
+	}
+}
+
+func (m *beInErroneousState) FailureMessage(actual interface{}) (message string) {
+	if len(m.expectedMessage) == 0 {
+		return "is not in an erroneous state"
+	}
+
+	return fmt.Sprintf("is not in an erroneous state with message '%s'", message)
+}
+
+func (m *beInErroneousState) NegatedFailureMessage(actual interface{}) (message string) {
+	if len(m.expectedMessage) == 0 {
+		return "is in an erroneous state"
+	}
+
+	return fmt.Sprintf("is in an erroneous state with message '%s'", message)
+}
+
+func HaveInstrumentedObjectReferenceFor(object runtime.Object) types.GomegaMatcher {
+	return &haveInstrumentedObjectReferenceFor{
+		object: object,
+	}
+}
+
+type haveInstrumentedObjectReferenceFor struct {
+	object runtime.Object
+}
+
+func (m *haveInstrumentedObjectReferenceFor) Match(actual interface{}) (bool, error) {
+	var lumigo *operatorv1alpha1.Lumigo
+	switch a := actual.(type) {
+	case *operatorv1alpha1.Lumigo:
+		lumigo = a
+	default:
+		return false, fmt.Errorf("HasInstrumentedObjectReference matcher expects a *operatorv1alpha1.Lumigo; got:\n%s", format.Object(actual, 1))
+	}
+
+	ref, err := reference.GetReference(scheme.Scheme, m.object)
+	if err != nil {
+		return false, err
+	}
+
+	for _, actualRef := range lumigo.Status.InstrumentedResources {
+		if ref.Namespace == actualRef.Namespace && ref.Name == actualRef.Name && ref.Kind == actualRef.Kind {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (m *haveInstrumentedObjectReferenceFor) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("does not have the following object as instrumented reference: %+v", m.object)
+}
+
+func (m *haveInstrumentedObjectReferenceFor) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("has the following object as instrumented reference: %+v", m.object)
+}
+
+func BeMonitoringNamespace(namespace string) types.GomegaMatcher {
+	return &beMonitoringNamespace{
+		expectedMonitoredNamespace: namespace,
+	}
+}
+
+type beMonitoringNamespace struct {
+	expectedMonitoredNamespace string
+}
+
+func (m *beMonitoringNamespace) Match(actual interface{}) (bool, error) {
+	actualMonitoredNamespaces, err := parseJsonFile(actual)
+	if err != nil {
+		return false, err
+	}
+
+	for monitoredNamespace := range actualMonitoredNamespaces {
+		if monitoredNamespace == m.expectedMonitoredNamespace {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (m *beMonitoringNamespace) FailureMessage(actual interface{}) (message string) {
+	actualMonitoredNamespaces, err := parseJsonFile(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	return fmt.Sprintf(
+		"is not monitoring the namespace '%s'; monitored namespaces: %v",
+		m.expectedMonitoredNamespace,
+		reflect.ValueOf(actualMonitoredNamespaces).MapKeys(),
+	)
+}
+
+func (m *beMonitoringNamespace) NegatedFailureMessage(actual interface{}) (message string) {
+	actualMonitoredNamespaces, err := parseJsonFile(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	return fmt.Sprintf(
+		"is monitoring the namespace '%s'; monitored namespaces: %v",
+		m.expectedMonitoredNamespace,
+		reflect.ValueOf(actualMonitoredNamespaces).MapKeys(),
+	)
+}
+
+func parseJsonFile(actual interface{}) (map[string]string, error) {
+	var actualFile string
+	switch a := actual.(type) {
+	case string:
+		actualFile = a
+	default:
+		return nil, fmt.Errorf("BeJsonFileMatching matcher expects a string; got:\n%s", format.Object(actual, 1))
+	}
+
+	actualBytes, err := os.ReadFile(actualFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]string, 0), nil
+		} else {
+			return nil, fmt.Errorf("cannot read the actual file '%s': %w", actualFile, err)
+		}
+	}
+
+	var monitoredNamespaces map[string]string
+	if err := json.Unmarshal(actualBytes, &monitoredNamespaces); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal actual file '%s': %w", actualFile, err)
+	}
+
+	return monitoredNamespaces, nil
+}

--- a/controllers/internal/sorting/sorting_appsv1.go
+++ b/controllers/internal/sorting/sorting_appsv1.go
@@ -1,0 +1,57 @@
+package sorting
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type ByDaemonsetName []appsv1.DaemonSet
+
+func (s ByDaemonsetName) Len() int {
+	return len(s)
+}
+func (s ByDaemonsetName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByDaemonsetName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+type ByDeploymentName []appsv1.Deployment
+
+func (s ByDeploymentName) Len() int {
+	return len(s)
+}
+func (s ByDeploymentName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByDeploymentName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+type ByReplicaSetName []appsv1.ReplicaSet
+
+func (s ByReplicaSetName) Len() int {
+	return len(s)
+}
+func (s ByReplicaSetName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByReplicaSetName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+type ByStatefulSetName []appsv1.StatefulSet
+
+func (s ByStatefulSetName) Len() int {
+	return len(s)
+}
+func (s ByStatefulSetName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByStatefulSetName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}

--- a/controllers/internal/sorting/sorting_batchv1.go
+++ b/controllers/internal/sorting/sorting_batchv1.go
@@ -1,0 +1,31 @@
+package sorting
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+type ByCronJobName []batchv1.CronJob
+
+func (s ByCronJobName) Len() int {
+	return len(s)
+}
+func (s ByCronJobName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByCronJobName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+type ByJobName []batchv1.Job
+
+func (s ByJobName) Len() int {
+	return len(s)
+}
+func (s ByJobName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByJobName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}

--- a/controllers/internal/sorting/sorting_lumigo.go
+++ b/controllers/internal/sorting/sorting_lumigo.go
@@ -1,0 +1,19 @@
+package sorting
+
+import (
+	operatorv1alpha1 "github.com/lumigo-io/lumigo-kubernetes-operator/api/v1alpha1"
+)
+
+// To be used with sort.Sort
+type ByCreationTime []operatorv1alpha1.Lumigo
+
+func (s ByCreationTime) Len() int {
+	return len(s)
+}
+func (s ByCreationTime) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s ByCreationTime) Less(i, j int) bool {
+	return s[i].CreationTimestamp.Before(&s[j].CreationTimestamp)
+}

--- a/webhooks/injector/injector_webhook_suite_test.go
+++ b/webhooks/injector/injector_webhook_suite_test.go
@@ -82,6 +82,7 @@ var statusActive = operatorv1alpha1.LumigoStatus{
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		},
 	},
+	InstrumentedResources: make([]corev1.ObjectReference, 0),
 }
 
 var statusErroneous = operatorv1alpha1.LumigoStatus{


### PR DESCRIPTION
List in the Lumigo resource status the currently instrumented resources. For example:

```yaml
$ kubectl describe lumigo -n my-namespace
Name:         lumigo
Namespace:    my-namespace
API Version:  operator.lumigo.io/v1alpha1
Kind:         Lumigo
Metadata:
  ... # Data removed for readability
Spec:
  ... # Data removed for readability
Status:
  Conditions:
  ... # Data removed for readability
  Instrumented Resources:
    API Version:       apps/v1
    Kind:              StatefulSet
    Name:              my-statefulset
    Namespace:         my-namespace
    Resource Version:  320123
    UID:               93d6d809-ac2a-43a9-bc07-f0d4e314efcc
```

Closes #36