### PR TITLE
fix: Use fixed name `lumigo-kubernetes-operator` for operator service-account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can verify that the Lumigo Kubernetes operator is up and running with:
 ```sh
 $ kubectl get pods -n lumigo-system
 NAME                                                         READY   STATUS    RESTARTS   AGE
-lumigo-lumigo-operator-controller-manager-7fc8f67bcc-ffh5k   2/2     Running   0          56s
+lumigo-kubernetes-operator-7fc8f67bcc-ffh5k   2/2     Running   0          56s
 ```
 
 **Note:** While installing the Lumigo Kubernetes operator via [`kustomize`](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) is generally expected to work (except the [uninstallation of instrumentation on removal](#remove-injection-from-existing-resources)), it is not actually supported[^1].

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Your monitored applications, however, can run on the Fargate profile without any
 Installing the Lumigo Kubernetes operator on an EKS cluster without EC2-backed nodegroups, results in the operator pods staying in `Pending` state:
 
 ```sh
-$ kubectl describe pod -n lumigo-system lumigo-lumigo-operator-controller-manager-5999997fb7-cvg5h
+$ kubectl describe pod -n lumigo-system lumigo-kubernetes-operator-5999997fb7-cvg5h
 
 Namespace:    	lumigo-system
 Priority:     	0
-Service Account:  lumigo-lumigo-operator-controller-manager
+Service Account:  lumigo-kubernetes-operator
 Node:         	<none>
 Labels:       	app.kubernetes.io/instance=lumigo
               	app.kubernetes.io/name=lumigo-operator

--- a/charts/lumigo-operator/README.md
+++ b/charts/lumigo-operator/README.md
@@ -18,7 +18,7 @@ You can verify that the Lumigo Operator is up and running with:
 ```sh
 $ kubectl get pods -n lumigo-system
 NAME                                                         READY   STATUS    RESTARTS   AGE
-lumigo-lumigo-operator-controller-manager-7fc8f67bcc-ffh5k   2/2     Running   0          56s
+lumigo-kubernetes-operator-7fc8f67bcc-ffh5k   2/2     Running   0          56s
 ```
 
 ## Enabling automatic tracing

--- a/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
+++ b/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
@@ -286,7 +286,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: 1234
-      serviceAccountName: {{ include "helm.fullname" . }}-controller-manager
+      serviceAccountName: lumigo-kubernetes-operator
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert

--- a/charts/lumigo-operator/templates/leader-election-rbac.yaml
+++ b/charts/lumigo-operator/templates/leader-election-rbac.yaml
@@ -55,5 +55,5 @@ roleRef:
   name: '{{ include "helm.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "helm.fullname" . }}-controller-manager'
+  name: 'lumigo-kubernetes-operator'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/lumigo-operator/templates/manager-rbac.yaml
+++ b/charts/lumigo-operator/templates/manager-rbac.yaml
@@ -97,5 +97,5 @@ roleRef:
   name: '{{ include "helm.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "helm.fullname" . }}-controller-manager'
+  name: 'lumigo-kubernetes-operator'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/lumigo-operator/templates/proxy-rbac.yaml
+++ b/charts/lumigo-operator/templates/proxy-rbac.yaml
@@ -36,5 +36,5 @@ roleRef:
   name: '{{ include "helm.fullname" . }}-proxy-role'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "helm.fullname" . }}-controller-manager'
+  name: 'lumigo-kubernetes-operator'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/lumigo-operator/templates/service-account.yaml
+++ b/charts/lumigo-operator/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "helm.fullname" . }}-controller-manager
+  name: lumigo-kubernetes-operator
   labels:
   {{- include "helm.labels" . | nindent 4 }}
     app.kubernetes.io/component: rbac

--- a/charts/lumigo-operator/templates/uninstallation/uninstall-hook.yaml
+++ b/charts/lumigo-operator/templates/uninstallation/uninstall-hook.yaml
@@ -39,4 +39,4 @@ spec:
       securityContext:
         runAsNonRoot: true
         fsGroup: 1234
-      serviceAccountName: {{ include "helm.fullname" . }}-controller-manager
+      serviceAccountName: lumigo-kubernetes-operator

--- a/helm.yaml
+++ b/helm.yaml
@@ -49,7 +49,7 @@ spec:
       securityContext:
         fsGroup: 1234
         runAsNonRoot: true
-      serviceAccountName: lumigo-lumigo-operator-controller-manager
+      serviceAccountName: lumigo-kubernetes-operator
 ---
 # Source: lumigo-operator/templates/controller-deployment-and-webhooks.yaml
 apiVersion: v1
@@ -203,7 +203,7 @@ metadata:
     app.kubernetes.io/part-of: lumigo
     app.kubernetes.io/version: "0"
     helm.sh/chart: lumigo-operator-0
-  name: lumigo-lumigo-operator-controller-manager
+  name: lumigo-kubernetes-operator
 ---
 # Source: lumigo-operator/templates/leader-election-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -409,7 +409,7 @@ roleRef:
   name: lumigo-lumigo-operator-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: lumigo-lumigo-operator-controller-manager
+    name: lumigo-kubernetes-operator
     namespace: lumigo-system
 ---
 # Source: lumigo-operator/templates/manager-rbac.yaml
@@ -432,7 +432,7 @@ roleRef:
   name: lumigo-lumigo-operator-manager-role
 subjects:
   - kind: ServiceAccount
-    name: lumigo-lumigo-operator-controller-manager
+    name: lumigo-kubernetes-operator
     namespace: lumigo-system
 ---
 # Source: lumigo-operator/templates/proxy-rbac.yaml
@@ -455,7 +455,7 @@ roleRef:
   name: lumigo-lumigo-operator-proxy-role
 subjects:
   - kind: ServiceAccount
-    name: lumigo-lumigo-operator-controller-manager
+    name: lumigo-kubernetes-operator
     namespace: lumigo-system
 ---
 # Source: lumigo-operator/templates/metrics-service.yaml
@@ -712,7 +712,7 @@ spec:
       securityContext:
         fsGroup: 1234
         runAsNonRoot: true
-      serviceAccountName: lumigo-lumigo-operator-controller-manager
+      serviceAccountName: lumigo-kubernetes-operator
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert


### PR DESCRIPTION
Use fixed name lumigo-kubernetes-operator for operator service-account name