### PR TITLE
fix: Remove ignores from grype.yaml

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,5 +1,1 @@
 ignore:
-  # Only required until gomplate is released with https://github.com/hairyhenderson/gomplate/issues/1960 resolved
-  # TODO: Remove this once the above issue is resolved
-  - vulnerability: GHSA-449p-3h89-pw88
-  - vulnerability: GHSA-mw99-9chc-xw7r


### PR DESCRIPTION
These CVEs are resolved upstream, so we don't need to ignore them

Resolves #87