### PR TITLE
fix: allow using metrics with pre-existing secret

### DIFF
--- a/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
+++ b/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
@@ -20,7 +20,7 @@ data:
   tls.key: {{ $cert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
 ---
-{{- if and .Values.lumigoToken.value .Values.clusterCollection.metrics.enabled }}
+{{- if and .Values.clusterCollection.metrics.enabled .Values.lumigoToken.value }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -246,12 +246,13 @@ spec:
           value: "{{ .Values.endpoint.otlp.logs_url }}"
         - name: LUMIGO_METRICS_ENDPOINT
           value: "{{ .Values.endpoint.otlp.metrics_url }}"
-{{- if and .Values.lumigoToken.value .Values.clusterCollection.metrics.enabled }}
+{{- if .Values.clusterCollection.metrics.enabled }}
         - name: LUMIGO_INFRA_METRICS_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.lumigoToken.secretName }}
               key: {{ .Values.lumigoToken.secretKey }}
+              optional: true
         - name: LUMIGO_INFRA_METRICS_SCRAPING_FREQUENCY
           value: "{{ .Values.clusterCollection.metrics.frequency }}"
 {{- end }}

--- a/telemetryproxy/docker/etc/config.yaml.tpl
+++ b/telemetryproxy/docker/etc/config.yaml.tpl
@@ -138,7 +138,7 @@ exporters:
   otlphttp/lumigo_metrics:
     endpoint: {{ env.Getenv "LUMIGO_METRICS_ENDPOINT" "https://ga-otlp.lumigo-tracer-edge.golumigo.com" }}
     headers:
-      Authorization: "LumigoToken {{ env.Getenv "LUMIGO_INFRA_METRICS_TOKEN" }}"
+      Authorization: "LumigoToken {{ $infraMetricsToken }}"
 {{- end }}
 {{- if $debug }}
   logging:


### PR DESCRIPTION
The current setup does not work if a `secretToken.value` value is not set when running `helm install`, which means only a token provided during installation time can be used.
The fix here allows leaving the `secretToken.value` blank, and providing a name + key of an existing secret holding the token.