### PR TITLE
fix: do not fail on a missing-secret

### DIFF
--- a/charts/lumigo-operator/templates/cluster-agent.yaml
+++ b/charts/lumigo-operator/templates/cluster-agent.yaml
@@ -153,6 +153,7 @@ spec:
             secretKeyRef:
               name: {{ .Values.lumigoToken.secretName }}
               key: {{ .Values.lumigoToken.secretKey }}
+              optional: true
         - name: LUMIGO_LOGS_ENDPOINT
           value: "{{ .Values.endpoint.otlp.logs_url }}"
         - name: KUBERNETES_CLUSTER_NAME


### PR DESCRIPTION
When the pod log-file collector fails to find the secret with the Lumigo token, we'd like it to not fail but instead start-up an allow creating the secret later 