### PR TITLE
fix: add missing node label on infra metrics

### DIFF
--- a/charts/lumigo-operator/templates/cluster-agent-service.yaml
+++ b/charts/lumigo-operator/templates/cluster-agent-service.yaml
@@ -18,5 +18,6 @@ spec:
       protocol: TCP
       port: {{ .Values.prometheusNodeExporter.service.port }}
       targetPort: {{ .Values.prometheusNodeExporter.service.port }}
-  type: ClusterIP
+      nodePort: 32700
+  type: NodePort
 {{- end }}

--- a/charts/lumigo-operator/templates/cluster-agent-service.yaml
+++ b/charts/lumigo-operator/templates/cluster-agent-service.yaml
@@ -18,6 +18,6 @@ spec:
       protocol: TCP
       port: {{ .Values.prometheusNodeExporter.service.port }}
       targetPort: {{ .Values.prometheusNodeExporter.service.port }}
-      nodePort: 32700
+      nodePort: {{ .Values.prometheusNodeExporter.service.nodePort }}
   type: NodePort
 {{- end }}

--- a/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
+++ b/charts/lumigo-operator/templates/controller-deployment-and-webhooks.yaml
@@ -258,7 +258,7 @@ spec:
         - name: LUMIGO_CLUSTER_AGENT_SERVICE
           value: "{{ include "helm.fullname" . }}-cluster-agent-service.{{ .Release.Namespace }}.svc.cluster.local"
         - name: LUMIGO_PROM_NODE_EXPORTER_PORT
-          value: "{{ .Values.prometheusNodeExporter.service.port }}"
+          value: "{{ .Values.prometheusNodeExporter.service.nodePort }}"
         - name: LUMIGO_KUBE_STATE_METRICS_SERVICE
           value: "{{ .Release.Name }}-kube-state-metrics.{{ .Release.Namespace }}.svc.cluster.local"
         - name: LUMIGO_KUBE_STATE_METRICS_PORT

--- a/charts/lumigo-operator/values.yaml
+++ b/charts/lumigo-operator/values.yaml
@@ -59,6 +59,7 @@ prometheusNodeExporter:
     tag: v1.8.2
   service:
     port: 9100
+    nodePort: 30090
   resources:
     limits:
       cpu: 500m

--- a/telemetryproxy/docker/etc/config.yaml.tpl
+++ b/telemetryproxy/docker/etc/config.yaml.tpl
@@ -49,11 +49,12 @@ receivers:
           kubernetes_sd_configs:
             - role: node
           relabel_configs:
-            # Relabel to set the target address to <InternalIP>:32700
             - source_labels: [__meta_kubernetes_node_address_InternalIP]
               action: replace
               target_label: __address__
-              replacement: '$$1:32700'
+              # Scrape a custom port provided by LUMIGO_PROM_NODE_EXPORTER_PORT.
+              # '$$1' escapes '$1', as Gomplate otherwise thinks it's an environment variable.
+              replacement: '$$1:$LUMIGO_PROM_NODE_EXPORTER_PORT'
             - source_labels: [__meta_kubernetes_node_name]
               action: replace
               target_label: node


### PR DESCRIPTION
This PR changes the way metrics are exposed to the Prometheus receiver scraper - having it exposed through a `ClusterIP` service made all the metrics considered as coming from a single node, which is the service's logical name.
Changing it to `NodePort` allows the scraper to figure out the source node, and label the metric accordingly.