### PR TITLE
feat: report KSM label metrics

### DIFF
--- a/charts/lumigo-operator/values.yaml
+++ b/charts/lumigo-operator/values.yaml
@@ -105,3 +105,5 @@ clusterCollection:
 kube-state-metrics:
   service:
     port: 8086
+  extraArgs:
+    - --metric-labels-allowlist=namespaces=[namespace],daemonsets=[daemonset,namespace],deployments=[deployment,namespace],replicasets=[replicaset,namespace],statefulsets=[statefulset,namespace],jobs=[job,namespace],cronjobs=[cronjob,namespace],pods=[pod,namespace],nodes=[node]

--- a/tests/kubernetes-distros/kind/lumigooperator_metrics_test.go
+++ b/tests/kubernetes-distros/kind/lumigooperator_metrics_test.go
@@ -97,6 +97,7 @@ func TestLumigoOperatorInfraMetrics(t *testing.T) {
 				prometheusNodeExporterMetricsFound := false
 				cadvisorMetricsFound := false
 				kubeStateMetricsFound := false
+				labelMetricsFound := false
 
 				for _, metric := range metrics {
 					if metric.Name() == "node_cpu_seconds_total" {
@@ -118,6 +119,10 @@ func TestLumigoOperatorInfraMetrics(t *testing.T) {
 					if metric.Name() == "kube_pod_status_scheduled" {
 						kubeStateMetricsFound = true
 					}
+
+					if metric.Name() == "kube_deployment_labels" {
+						labelMetricsFound = true
+					}
 				}
 
 				if !prometheusNodeExporterMetricsFound {
@@ -132,6 +137,11 @@ func TestLumigoOperatorInfraMetrics(t *testing.T) {
 
 				if !kubeStateMetricsFound {
 					t.Logf("could not find kube-state-metrics. Seen metrics: %v", uniqueMetricNames)
+					return false, nil
+				}
+
+				if !labelMetricsFound {
+					t.Logf("could not find label metrics. Seen metrics: %v", uniqueMetricNames)
 					return false, nil
 				}
 


### PR DESCRIPTION
This PR adds the `kube_<kind>_labels` for all kinds we're interested in, effectively allowing us to get the current state of the cluster in terms of all running resources (deployments, replicasets, daemonsets, etc.) - which creates a more efficient and faster "snapshot" than relying on the existing resources pipeline