### PR TITLE
feat: support monitoring namespaces on installation

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -272,7 +272,7 @@ jobs:
         if: always()
       - name: Store OTLP test data as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kind-otlp-data
           # Skip container images

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ monitoredNamespaces:
 " | helm upgrade -i lumigo lumigo/lumigo-operator --namespace lumigo-system --create-namespace --values -
 ```
 
+**Notes**
+1. adding additional namespace can be done by re-running the command above with the only additional namespace added to the `monitoredNamespaces` list (no need to re-include the ones from previous runs).
+2. Removing namespaces monitored via this method can be done by running:
+
+```sh
+kubectl delete lumigo --all --namespace <monitored namespace>
+kubectl delete secret lumigo-credentials --namespace <monitored namespace>
+```
+for each monitored namespace.
+
 #### Install only
 
 The following command installs the operator but requires you to create a secret and a Lumigo CRD per each monitored namespace, as described in the [Enabling automatic tracing](#enabling-automatic-tracing) section:

--- a/README.md
+++ b/README.md
@@ -32,14 +32,8 @@ monitoredNamespaces:
 ```
 
 **Notes**
-1. adding additional namespace can be done by re-running the command above with the only additional namespace added to the `monitoredNamespaces` list (no need to re-include the ones from previous runs).
-2. Removing namespaces monitored via this method can be done by running:
-
-```sh
-kubectl delete lumigo --all --namespace <monitored namespace>
-kubectl delete secret lumigo-credentials --namespace <monitored namespace>
-```
-for each monitored namespace.
+1. adding additional namespace(s) can be done by re-running the command above with the only additional namespace(s) added to the `monitoredNamespaces` list (no need to re-include the ones from previous runs).
+2. Opting out from Lumigo monitoring a namespace specified in the `monitoredNamespaces` list is explained in the [#### Remove injection from existing resources](#remove-injection-from-existing-resources) section.
 
 #### Install only
 
@@ -366,6 +360,12 @@ spec:
 ```
 
 #### Remove injection from existing resources
+
+To opt-out from Lumigo monitoring a namespace, you can delete the Lumigo resource from that namespace along with its corresponding secret:
+```sh
+kubectl delete lumigo --all --namespace <monitored namespace>
+kubectl delete secret lumigo-credentials --namespace <monitored namespace>
+```
 
 By default, when detecting the deletion of the Lumigo resource in a namespace, the Lumigo controller will remove instrumentation from existing resources of the [supported types](#supported-resource-types).
 The injection will cause new pods to be created for daemonsets, deployments, replicasets, statefulsets and jobs; cronjobs will spawn non-injected pods at the next iteration.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,30 @@ The Kubernetes operator of Lumigo provides a one-click solution to monitoring Ku
 
 ### Installation
 
-Install the Lumigo Kubernetes operator in your Kubernets cluster with [helm](https://helm.sh/):
+Install the Lumigo Kubernetes operator in your Kubernets cluster with [helm](https://helm.sh/), with one of the following methods:
+
+#### Install & monitor namespaces
+
+The following command installs the operator and immediately applies monitoring to the specified namespaces, with traces or logs enabled or disabled as specified (defaulting to `true` for both):
+
+```sh
+echo "
+cluster:
+  name: <your cluster name>
+lumigoToken:
+  value: <your Lumigo token>
+monitoredNamespaces:
+  - namespace: my-namespace-1-traces-and-logs
+  - namespace: my-namespace-only-traces
+    loggingEnabled: false
+  - namespace: my-namespace-only-logs
+    tracingEnabled: false
+" | helm upgrade -i lumigo lumigo/lumigo-operator --namespace lumigo-system --create-namespace --values -
+```
+
+#### Install only
+
+The following command installs the operator but requires you to create a secret and a Lumigo CRD per each monitored namespace, as described in the [Enabling automatic tracing](#enabling-automatic-tracing) section:
 
 ```sh
 helm repo add lumigo https://lumigo-io.github.io/lumigo-kubernetes-operator && \
@@ -21,7 +44,7 @@ helm install lumigo lumigo/lumigo-operator \
   --set lumigoToken.value=<token>
 ```
 
-**Notes:** 
+**Notes:**
 1. You have the option to alter the namespace from `lumigo-system` to a name of your choosing, but its important to be aware that doing so might cause slight discrepancies throughout the steps below.
 2. The `lumigoToken.value` is optional, but is highly recommended in order properly populate the cluster overview info in the Lumigo platform and have many other K8s-sourced metrics reported automatically. You can use the token from any Lumigo project, and cluster-wide metrics will be forwarded to it once the installation is complete.
 3. The `cluster.name` is optional, but highly advised, see the [Naming your cluster](#naming-your-cluster) section.

--- a/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
+++ b/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.lumigoToken .Values.quickstart }}
+{{ if and .Values.lumigoToken .Values.monitoredNamespaces }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,7 +32,7 @@ spec:
         command:
           - "/manager"
         args:
-          - --quickstart={{ .Values.quickstart | toJson }}
+          - --quickstart={{ .Values.monitoredNamespaces | toJson }}
           - --lumigo-token={{ .Values.lumigoToken.value }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
+++ b/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
@@ -1,0 +1,44 @@
+{{ if and .Values.lumigoToken .Values.quickstart }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "helm.fullname" . }}-install-hook
+  labels:
+  {{- include "helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: lumigo
+    app.kubernetes.io/part-of: lumigo
+    control-plane: controller-manager
+    lumigo.auto-trace: 'false' # We do not need the operator to inject itself
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation #,hook-succeeded # we skip hook-failed so that we can look up logs if it fails
+spec:
+  completions: 1
+  backoffLimit: 2
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+      {{- include "helm.selectorLabels" . | nindent 8 }}
+        lumigo.auto-trace: 'false' # We do not need the operator to inject itself
+        control-plane: controller-manager
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 120 # Unfortunately, as of v3.11, Helm does not expose to templates its own timeout
+      containers:
+      - name: install-hook
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+        command: ["/manager", "--quickstart", "{{ .Values.quickstart }}", "--lumigo-token", "{{ .Values.lumigoToken }}"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1234
+      serviceAccountName: lumigo-kubernetes-operator
+{{- end }}

--- a/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
+++ b/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
@@ -29,7 +29,11 @@ spec:
       containers:
       - name: install-hook
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
-        command: ["/manager", "--quickstart", "{{ .Values.quickstart }}", "--lumigo-token", "{{ .Values.lumigoToken }}"]
+        command:
+          - "/manager"
+        args:
+          - "--quickstart={{ .Values.quickstart | toJson }}"
+          - "--lumigo-token={{ .Values.lumigoToken.value }}"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
+++ b/charts/lumigo-operator/templates/installation/install-upgrade-hook.yaml
@@ -12,7 +12,7 @@ metadata:
     lumigo.auto-trace: 'false' # We do not need the operator to inject itself
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation #,hook-succeeded # we skip hook-failed so that we can look up logs if it fails
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded # we skip hook-failed, so the job will be kept for troubleshooting in case of a failure
 spec:
   completions: 1
   backoffLimit: 2
@@ -32,8 +32,8 @@ spec:
         command:
           - "/manager"
         args:
-          - "--quickstart={{ .Values.quickstart | toJson }}"
-          - "--lumigo-token={{ .Values.lumigoToken.value }}"
+          - --quickstart={{ .Values.quickstart | toJson }}
+          - --lumigo-token={{ .Values.lumigoToken.value }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/lumigo-operator/templates/leader-election-rbac.yaml
+++ b/charts/lumigo-operator/templates/leader-election-rbac.yaml
@@ -57,3 +57,39 @@ subjects:
 - kind: ServiceAccount
   name: 'lumigo-kubernetes-operator'
   namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm.fullname" . }}-quickstart-management
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: lumigo
+    app.kubernetes.io/part-of: lumigo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - lumigoes
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm.fullname" . }}-quickstart-management
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: lumigo
+    app.kubernetes.io/part-of: lumigo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "helm.fullname" . }}-quickstart-management'
+subjects:
+- kind: ServiceAccount
+  name: 'lumigo-kubernetes-operator'
+  namespace: '{{ .Release.Namespace }}'

--- a/controller/src/main.go
+++ b/controller/src/main.go
@@ -67,25 +67,25 @@ func init() {
 }
 
 type QuickstartSetting struct {
-	Namespace     string `json:"namespace"`
-	TracesEnabled *bool  `json:"tracesEnabled,omitempty"`
-	LogsEnabled   *bool  `json:"logsEnabled,omitempty"`
+	Namespace       string 	`json:"namespace"`
+	TracingEnabled  *bool  	`json:"tracingEnabled,omitempty"`
+	LoggingEnabled  *bool  	`json:"loggingEnabled,omitempty"`
 }
 
 func (qs *QuickstartSetting) GetTracesEnabledOrDefault() *bool {
-	if qs.TracesEnabled == nil {
+	if qs.TracingEnabled == nil {
 		newTrue := true
 		return &newTrue
 	}
-	return qs.TracesEnabled
+	return qs.TracingEnabled
 }
 
 func (qs *QuickstartSetting) GetLogsEnabledOrDefault() *bool {
-	if qs.LogsEnabled == nil {
+	if qs.LoggingEnabled == nil {
 		newTrue := true
 		return &newTrue
 	}
-	return qs.LogsEnabled
+	return qs.LoggingEnabled
 }
 
 func main() {

--- a/controller/src/main.go
+++ b/controller/src/main.go
@@ -68,8 +68,24 @@ func init() {
 
 type QuickstartSetting struct {
 	Namespace     string `json:"namespace"`
-	TracesEnabled bool   `json:"tracesEnabled"`
-	LogsEnabled   bool   `json:"logsEnabled"`
+	TracesEnabled *bool  `json:"tracesEnabled,omitempty"`
+	LogsEnabled   *bool  `json:"logsEnabled,omitempty"`
+}
+
+func (qs *QuickstartSetting) GetTracesEnabledOrDefault() *bool {
+	if qs.TracesEnabled == nil {
+		newTrue := true
+		return &newTrue
+	}
+	return qs.TracesEnabled
+}
+
+func (qs *QuickstartSetting) GetLogsEnabledOrDefault() *bool {
+	if qs.LogsEnabled == nil {
+		newTrue := true
+		return &newTrue
+	}
+	return qs.LogsEnabled
 }
 
 func main() {
@@ -377,10 +393,10 @@ func createQuickstartObjects(quickstartSettings string, lumigoToken string) erro
 					},
 				},
 				Tracing: operatorv1alpha1.TracingSpec{
-					Enabled: &setting.TracesEnabled,
+					Enabled: setting.GetTracesEnabledOrDefault(),
 				},
 				Logging: operatorv1alpha1.LoggingSpec{
-					Enabled: &setting.LogsEnabled,
+					Enabled: setting.GetLogsEnabledOrDefault(),
 				},
 			},
 		}

--- a/tests/kubernetes-distros/kind/internal/context.go
+++ b/tests/kubernetes-distros/kind/internal/context.go
@@ -19,6 +19,7 @@ var (
 	ContextTestAppBusyboxIncludedContainerNamePrefix    = ContextKey("test-apps/busybox/included-container/name")
 	ContextTestAppBusyboxExcludedContainerNamePrefix    = ContextKey("test-apps/busybox/excluded-container/name")
 	ContextTestAppNamespacePrefix                       = ContextKey("test-apps/namespace/prefix")
+	ContextQuickstartNamespace                          = ContextKey("test-apps/namespace/quickstart")
 )
 
 func (c ContextKey) String() string {

--- a/tests/kubernetes-distros/kind/internal/install_operator.go
+++ b/tests/kubernetes-distros/kind/internal/install_operator.go
@@ -35,6 +35,7 @@ func installLumigoOperator(ctx context.Context, client klient.Client, kubeconfig
 	lumigoToken := ctx.Value(ContextKeyLumigoToken).(string)
 	busyboxExcludedContainerNamePrefix := ctx.Value(ContextTestAppBusyboxExcludedContainerNamePrefix).(string)
 	testNamespacePrefix := ctx.Value(ContextTestAppNamespacePrefix).(string)
+	quickstartNamespace := ctx.Value(ContextQuickstartNamespace).(string)
 
 	var curDir, _ = os.Getwd()
 	chartDir := filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(curDir))), "charts", "lumigo-operator")
@@ -63,6 +64,9 @@ func installLumigoOperator(ctx context.Context, client klient.Client, kubeconfig
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.enabled=%v", true)), // Enable log collection via pod logs-files
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].namespacePattern=%s*", testNamespacePrefix)),
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].containerPattern=%s*", busyboxExcludedContainerNamePrefix)),
+		helm.WithArgs(fmt.Sprintf("--set quickstart[0].namespace=%s", quickstartNamespace)),
+		helm.WithArgs("--set quickstart[0].logsEnabled=true"),
+		helm.WithArgs("--set quickstart[0].tracesEnabled=true"),
 		helm.WithArgs("--debug"), // Helm debug output on install
 		helm.WithWait(),
 		helm.WithTimeout("3m"),

--- a/tests/kubernetes-distros/kind/internal/install_operator.go
+++ b/tests/kubernetes-distros/kind/internal/install_operator.go
@@ -64,10 +64,7 @@ func installLumigoOperator(ctx context.Context, client klient.Client, kubeconfig
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.enabled=%v", true)), // Enable log collection via pod logs-files
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].namespacePattern=%s*", testNamespacePrefix)),
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].containerPattern=%s*", busyboxExcludedContainerNamePrefix)),
-		// Enable monitoring of a namespace during installation time
-		helm.WithArgs(fmt.Sprintf("--set monitoredNamespaces[0].namespace=%s", quickstartNamespace)),
-		helm.WithArgs("--set monitoredNamespaces[0].logsEnabled=true"),
-		helm.WithArgs("--set monitoredNamespaces[0].tracesEnabled=true"),
+		helm.WithArgs(fmt.Sprintf("--set monitoredNamespaces[0].namespace=%s", quickstartNamespace)), // Enable monitoring of a namespace during installation time
 		helm.WithArgs("--debug"), // Helm debug output on install
 		helm.WithWait(),
 		helm.WithTimeout("3m"),

--- a/tests/kubernetes-distros/kind/internal/install_operator.go
+++ b/tests/kubernetes-distros/kind/internal/install_operator.go
@@ -59,18 +59,18 @@ func installLumigoOperator(ctx context.Context, client klient.Client, kubeconfig
 		helm.WithArgs(fmt.Sprintf("--set endpoint.otlp.url=%s", otlpSinkUrl)),
 		helm.WithArgs(fmt.Sprintf("--set endpoint.otlp.logs_url=%s", otlpSinkUrl)),
 		helm.WithArgs(fmt.Sprintf("--set endpoint.otlp.metrics_url=%s", otlpSinkUrl)),
-		helm.WithArgs(fmt.Sprintf("--set lumigoToken.value=%s", lumigoToken)), // Use the the test-token for infra metrics as well
-		helm.WithArgs(fmt.Sprintf("--set debug.enabled=%v", operatorDebug)), // Operator debug logging at runtime
+		helm.WithArgs(fmt.Sprintf("--set lumigoToken.value=%s", lumigoToken)),       // Use the the test-token for infra metrics as well
+		helm.WithArgs(fmt.Sprintf("--set debug.enabled=%v", operatorDebug)),         // Operator debug logging at runtime
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.enabled=%v", true)), // Enable log collection via pod logs-files
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].namespacePattern=%s*", testNamespacePrefix)),
 		helm.WithArgs(fmt.Sprintf("--set clusterCollection.logs.exclude[0].containerPattern=%s*", busyboxExcludedContainerNamePrefix)),
-		helm.WithArgs(fmt.Sprintf("--set quickstart[0].namespace=%s", quickstartNamespace)),
-		helm.WithArgs("--set quickstart[0].logsEnabled=true"),
-		helm.WithArgs("--set quickstart[0].tracesEnabled=true"),
+		// Enable monitoring of a namespace during installation time
+		helm.WithArgs(fmt.Sprintf("--set monitoredNamespaces[0].namespace=%s", quickstartNamespace)),
+		helm.WithArgs("--set monitoredNamespaces[0].logsEnabled=true"),
+		helm.WithArgs("--set monitoredNamespaces[0].tracesEnabled=true"),
 		helm.WithArgs("--debug"), // Helm debug output on install
 		helm.WithWait(),
 		helm.WithTimeout("3m"),
-
 	); err != nil {
 		return ctx, fmt.Errorf("failed to invoke helm install operation due to an error: %w", err)
 	}

--- a/tests/kubernetes-distros/kind/lumigooperator_logs_test.go
+++ b/tests/kubernetes-distros/kind/lumigooperator_logs_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr/testr"
-	"github.com/moby/moby/daemon/logger"
 	"golang.org/x/exp/slices"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -47,8 +45,6 @@ var (
 //    `kubectl` configuration
 
 func TestLumigoOperatorLogsEventsAndObjects(t *testing.T) {
-	logger := testr.New(t)
-
 	testAppDeploymentFeature := features.New("TestApp").
 		Setup(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 			client := config.Client()
@@ -798,7 +794,7 @@ func createAndDeleteTempDeployment(ctx context.Context, config *envconf.Config, 
 		return d.Status.AvailableReplicas == expectedReplicas && d.Status.ReadyReplicas == expectedReplicas
 	}))
 
-	logger.Info("Deployment %s/%s is ready", deployment.Namespace, deployment.Name)
+	println("Deployment %s/%s is ready", deployment.Namespace, deployment.Name)
 
 	if err := client.Resources().Delete(ctx, deployment); err != nil {
 		return err
@@ -806,7 +802,7 @@ func createAndDeleteTempDeployment(ctx context.Context, config *envconf.Config, 
 
 	wait.For(conditions.New(config.Client().Resources()).ResourceDeleted(deployment))
 
-	logger.Info("Deployment %s/%s is deleted", deployment.Namespace, deployment.Name)
+	println("Deployment %s/%s is deleted", deployment.Namespace, deployment.Name)
 
 	return nil
 }

--- a/tests/kubernetes-distros/kind/lumigooperator_logs_test.go
+++ b/tests/kubernetes-distros/kind/lumigooperator_logs_test.go
@@ -176,19 +176,6 @@ func TestLumigoOperatorLogsEventsAndObjects(t *testing.T) {
 
 			logger.Info("Deployment is ready")
 
-			// // Restart deployment to make sure it gets injected with the injector sidecar
-			// annotations := deployment.GetAnnotations()
-			// annotations["force-this-deployment-to-restart"] = "by-changing-some-random-annotation"
-			// deployment.SetAnnotations(annotations)
-			// if err := config.Client().Resources().Update(ctx, deployment); err != nil {
-			// 	t.Fatalf("Failed to restart deployment: %v", err)
-			// }
-
-			// wait.For(conditions.New(config.Client().Resources()).ResourceMatch(deployment, func(object k8s.Object) bool {
-			// 	d := object.(*appsv1.Deployment)
-			// 	return d.Status.AvailableReplicas == replicas && d.Status.ReadyReplicas == replicas
-			// }))
-
 			// Tear it all down
 			if err := client.Resources().Delete(ctx, deployment); err != nil {
 				t.Fatal(err)

--- a/tests/kubernetes-distros/kind/main_test.go
+++ b/tests/kubernetes-distros/kind/main_test.go
@@ -194,6 +194,8 @@ func TestMain(m *testing.M) {
 	testPythonImageName := fmt.Sprintf("%s:%s", internal.DEFAULT_PYTHON_IMG_NAME, runId)
 	testPythonImageArchivePath := filepath.Join(tmpDir, "test-python.tgz")
 
+	quickstartNamespace := "test-quickstart-ns"
+
 	ctx := context.WithValue(context.Background(), internal.ContextKeyRunId, runId)
 	ctx = context.WithValue(ctx, internal.ContextKeyKubernetesClusterName, kindClusterName)
 	ctx = context.WithValue(ctx, internal.ContextKeyOtlpSinkConfigPath, dataSinkConfigDir)
@@ -210,6 +212,7 @@ func TestMain(m *testing.M) {
 	ctx = context.WithValue(ctx, internal.ContextTestAppBusyboxIncludedContainerNamePrefix, "busybox-included")
 	ctx = context.WithValue(ctx, internal.ContextTestAppBusyboxExcludedContainerNamePrefix, "busybox-excluded")
 	ctx = context.WithValue(ctx, internal.ContextTestAppNamespacePrefix, "test-logs-ns")
+	ctx = context.WithValue(ctx, internal.ContextQuickstartNamespace, quickstartNamespace)
 
 	testEnv = env.NewWithConfig(cfg).WithContext(ctx)
 
@@ -237,6 +240,10 @@ func TestMain(m *testing.M) {
 		 * works only for local image, in the local Docker daemon).
 		 */
 		envfuncs.CreateNamespace(OTLP_SINK_NAMESPACE),
+
+		// Create the namespace on which the quickstart feature will operate
+		envfuncs.CreateNamespace(quickstartNamespace),
+
 		otlpSinkFeature,
 		lumigoOperatorFeature,
 	)


### PR DESCRIPTION
This PR introduces a feature that allow monitoring selected namespaces as a part of the operator installation, instead of creating secrets + CRDs later for each one