### PR TITLE
Fix binary architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ workflows:
 
     - lumigo-orb/prep-it-resources:
         context: common
+        venv_python_version: "3.9"
         requires:
           - lumigo-orb/is_environment_available
 

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -569,7 +569,7 @@ jobs:
         env:
           PROXY_IMG: ${{ matrix.ecr-registry }}/lumigo/lumigo-kubernetes-telemetry-proxy:${{ needs.validate-release-increment.outputs.version }}
         run: |
-          make docker-buildx-telemetry-proxy
+          make verify-telemetry-proxy-arch docker-buildx-telemetry-proxy
 
   publish-watchdog-ecr-image:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ docker-buildx-telemetry-proxy: ## Build and push docker image for the manager fo
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross && \
 	docker buildx create --name project-v3-builder && \
 	docker buildx use project-v3-builder && \
-	docker buildx build --push --provenance=false --platform=$(PLATFORMS) --tag ${PROXY_IMG} -f Dockerfile.cross --build-arg "version=$(VERSION)" . && \
+	docker buildx build --output=type=docker --provenance=false --platform=$(PLATFORMS) --tag ${PROXY_IMG} -f Dockerfile.cross --build-arg "version=$(VERSION)" . && \
 	docker buildx rm project-v3-builder && \
 	rm Dockerfile.cross )
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ docker-push: ## Push docker image with the manager.
 # To properly provided solutions that supports more than one platform you should use this option.
 PLATFORM_ARRAY := linux/arm64 linux/amd64 # linux/s390x linux/ppc64le
 # Convert the array to a comma-separated string for docker buildx
-PLATFORMS ?= $(subst $(space),$(comma),$(strip $(PLATFORM_ARRAY)))
+PLATFORMS ?= $(shell echo $(PLATFORM_ARRAY) | sed 's/ /,/g')
 
 .PHONY: docker-buildx
 docker-buildx: test docker-buildx-manager docker-buildx-telemetry-proxy docker-buildx-watchdog  ## Build and push docker image for the manager for cross-platform support

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,6 @@ docker-push: ## Push docker image with the manager.
 # To properly provided solutions that supports more than one platform you should use this option.
 PLATFORM_ARRAY := linux/arm64 linux/amd64 # linux/s390x linux/ppc64le
 # Convert the array to a comma-separated string for docker buildx
-comma := ,
-space :=
-space +=
 PLATFORMS ?= $(subst $(space),$(comma),$(strip $(PLATFORM_ARRAY)))
 
 .PHONY: docker-buildx
@@ -144,6 +141,7 @@ docker-buildx-manager: ## Build and push docker image for the manager for cross-
 	docker buildx rm project-v3-builder && \
 	rm Dockerfile.cross )
 
+.PHONY: verify-telemetry-proxy-arch
 verify-telemetry-proxy-arch:
 	@for platform in $(PLATFORM_ARRAY); do \
 		arch=$$(echo $$platform | cut -d'/' -f2); \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ docker-buildx-telemetry-proxy: ## Build and push docker image for the manager fo
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross && \
 	docker buildx create --name project-v3-builder && \
 	docker buildx use project-v3-builder && \
-	docker buildx build --output=type=docker --provenance=false --platform=$(PLATFORMS) --tag ${PROXY_IMG} -f Dockerfile.cross --build-arg "version=$(VERSION)" . && \
+	docker buildx build --push --provenance=false --platform=$(PLATFORMS) --tag ${PROXY_IMG} -f Dockerfile.cross --build-arg "version=$(VERSION)" . && \
 	docker buildx rm project-v3-builder && \
 	rm Dockerfile.cross )
 

--- a/telemetryproxy/Dockerfile
+++ b/telemetryproxy/Dockerfile
@@ -2,6 +2,9 @@
 FROM golang:1.23-alpine AS telemetry-proxy-builder
 
 ARG version='dev'
+ARG TARGETOS
+ARG TARGETARCH
+
 ENV VERSION=${version}
 
 RUN apk add --update make git
@@ -9,7 +12,7 @@ RUN apk add --update make git
 ADD ./src /src
 WORKDIR /src
 
-RUN make VERSION=${VERSION} OTELCONTRIBCOL_FILENAME=otelcontribcol otelcontribcolbuilder
+RUN make VERSION=${VERSION} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} OTELCONTRIBCOL_FILENAME=otelcontribcol otelcontribcolbuilder
 
 # We need to chmod files to fit the expected uid and gid
 # at runtime. Since we do not want to depend on buildkit,

--- a/telemetryproxy/src/Makefile
+++ b/telemetryproxy/src/Makefile
@@ -49,5 +49,5 @@ otelcontribcolbuilder: install-tools $(BUILDER)
 	# Split source generation and compilation in two steps, because the GOARCH and GOOS may be different when cross-compiling
 	mkdir -p ./dist
 	$(BUILDER) --skip-compilation --config ./builder/config.yaml --version $(VERSION)
-	cd ./dist/ && GOOS= GOARCH= CGO_ENABLED=0 $(GOCMD) build -trimpath -o $(OTELCONTRIBCOL_FILENAME) \
+	cd ./dist/ && GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 $(GOCMD) build -trimpath -o $(OTELCONTRIBCOL_FILENAME) \
 		$(BUILD_INFO) -tags $(GO_BUILD_TAGS) .

--- a/telemetryproxy/src/Makefile
+++ b/telemetryproxy/src/Makefile
@@ -26,7 +26,7 @@ $(TOOLS_BIN_DIR):
 	mkdir -p $@
 
 $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
-	cd $(TOOLS_MOD_DIR) && GOOS= GOARCH= $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
+	cd $(TOOLS_MOD_DIR) && GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
 
 ADDLICENCESE        := $(TOOLS_BIN_DIR)/addlicense
 MDLINKCHECK         := $(TOOLS_BIN_DIR)/markdown-link-check


### PR DESCRIPTION
*** do not merge - the verification `make` target fails on publish (after push to `main`) due to the image `vXY-arm64` missing - need to fix ***