### PR TITLE
feat: enable scalling and auto sharding for KSM

### DIFF
--- a/charts/lumigo-operator/templates/target-allocator-config.yaml
+++ b/charts/lumigo-operator/templates/target-allocator-config.yaml
@@ -92,8 +92,15 @@ config:
     - job_name: 'kube-state-metrics'
       metrics_path: /metrics
       scrape_interval: {{ .Values.clusterCollection.metrics.frequency }}
-      static_configs:
-        - targets: ['{{ .Release.Name }}-kube-state-metrics.{{ .Release.Namespace }}.svc.cluster.local:{{ index .Values "kube-state-metrics" "service" "port" }}']
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - {{ .Release.Namespace }}
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: {{ .Release.Name }}-{{ index .Values "kube-state-metrics" "nameOverride" | default "kube-state-metrics" }}
+          action: keep
       {{- if .Values.clusterCollection.metrics.essentialOnly }}
       metric_relabel_configs:
         - source_labels: [__name__]

--- a/charts/lumigo-operator/values.yaml
+++ b/charts/lumigo-operator/values.yaml
@@ -200,8 +200,17 @@ targetAllocator:
     repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
     tag: 0.124.0
 kube-state-metrics:
+  # Override the name to avoid conflicts with existing Deployment
+  nameOverride: "kube-state-metrics-sharded"
+  # Number of replicas for sharding
+  replicas: 1
   service:
     # controls the port in the KSM sub-chart
     port: 8086
+  statefulset:
+    enabled: true
+  autosharding:
+    enabled: true
   extraArgs:
     - --metric-labels-allowlist=namespaces=[namespace],daemonsets=[daemonset,namespace],deployments=[deployment,namespace],replicasets=[replicaset,namespace],statefulsets=[statefulset,namespace],jobs=[job,namespace],cronjobs=[cronjob,namespace],pods=[pod,namespace],nodes=[node]
+    - --use-apiserver-cache=true


### PR DESCRIPTION
to make the most of this pr we should run the upgrade command with the following values
helm upgrade lumigo ./charts/lumigo-operator \
  --namespace lumigo-system \
  --reuse-values \
  --set clusterCollection.metrics.essentialOnly=true \
  --set kube-state-metrics.replicas=<wanted replicas - default is 1> \
  --set kube-state-metrics.collectors='{deployments,statefulsets,daemonsets,cronjobs,jobs,nodes,pods,replicasets,namespaces}'